### PR TITLE
add max-width to iframe to preserve RWD

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -270,5 +270,9 @@ main {
     width: 92vw;
     text-align: center;
   }
+
+  iframe {
+      width: 100%;
+  }
   
 }


### PR DESCRIPTION
Tested on Firefox 115 and Chromium-ungoogled 110.